### PR TITLE
Add support for loading alerts from remote systems

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries Tesseract
 Author: Lightning Trumpet, Pentagram, and Matt Bernhardt
 Author URI: https://github.com/matt-bernhardt
-Version: 2.0.1-@@branch-@@commit
+Version: 2.1.0-@@branch-@@commit
 
 A parent theme for the Pentagram-designed branding of the MIT Libraries
 */

--- a/functions.php
+++ b/functions.php
@@ -193,13 +193,13 @@ function twentytwelve_scripts_styles() {
 		wp_localize_script( 'productionJS', 'mitlib', array(
 			'themeUrl' => get_template_directory_uri(),
 		));
+		wp_add_inline_script( 'productionJS', 'const ALERT_URL = "' . esc_js( get_option( 'source' ) ) . '";', 'before' );
 	}
 
 	if ( is_front_page() && ! is_child_theme() ) {
 		wp_enqueue_script( 'homeJS' );
-		wp_localize_script( 'homeJS', 'mitlib', array(
-			'themeUrl' => get_template_directory_uri(),
-		));
+		wp_localize_script( 'homeJS', 'mitlib', array( 'themeUrl' => get_template_directory_uri(), ) );
+		wp_add_inline_script( 'homeJS', 'const ALERT_URL = "' . esc_js( get_option( 'source' ) ) . '";', 'before' );
 	}
 
 	if ( is_page_template( 'page-authenticate.php' ) || is_page_template( 'page-forms.php' ) || is_page_template( 'page.php' ) ) {
@@ -1057,3 +1057,9 @@ function ssl_srcset( $sources ) {
 	return $sources;
 }
 add_filter( 'wp_calculate_image_srcset', 'ssl_srcset' );
+
+/**
+ * Initialize alerts object
+ */
+add_action( 'admin_init', array( 'Mitlib\Alerts\Settings', 'init' ) );
+add_action( 'admin_menu', array( 'Mitlib\Alerts\Dashboard', 'init' ) );

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -117,9 +117,13 @@ function showAlerts(json) {
 
 $(function(){
 
+	if ( 'undefined' === typeof ALERT_URL || '' === ALERT_URL ) {
+		ALERT_URL = '/wp-json/wp/v2/posts';
+	};
+
 	// This retrieves a list of posts, with additional parsing to determine if
 	// any are displayable alerts.
-	$.getJSON('/wp-json/wp/v2/posts')
+	$.getJSON( ALERT_URL )
 		.done(function(data){
 			showAlerts(data);
 		});

--- a/lib/class-alerts-dashboard.php
+++ b/lib/class-alerts-dashboard.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Class that defines a settings form for network-wide alerts.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 2.1.0
+ */
+
+namespace Mitlib\Alerts;
+
+/**
+ * Defines the dashboard / settings form which site builders use to update info
+ * about the alerts system. The settings themselves are defined in the Settings
+ * class.
+ */
+class Dashboard {
+
+	const PERMS = 'manage_options';
+
+	/**
+	 * Entry point for the dashboard (invoked in functions.php) - this defines
+	 * where the settings page will appear in the admin UI, and defines what
+	 * rendering callback will control its display.
+	 */
+	public static function init() {
+		if ( current_user_can( self::PERMS ) ) {
+			add_options_page(
+				'MIT Libraries Alerts',
+				'MITlib Alerts',
+				self::PERMS,
+				'mitlib-alerts',
+				array( 'Mitlib\Alerts\Dashboard', 'page' )
+			);
+		}
+	}
+
+	/**
+	 * Rendering callback for the page which holds the settings form. The call
+	 * to settings_fields do_settings_sections are references to the Settings
+	 * class.
+	 */
+	public static function page() {
+		// Permissions check.
+		if ( ! current_user_can( self::PERMS ) ) {
+			return;
+		}
+
+		// Store updated values if posted.
+		$action = filter_input( INPUT_POST, 'action' );
+		if ( ! empty( $action ) ) {
+			self::update();
+		}
+
+		// Render the form.
+		echo '<div class="wrap">';
+		echo '<h1>MIT Libraries Alerts settings</h1>';
+		echo '<form method="post" action="">';
+		wp_nonce_field( 'custom_nonce_action', 'custom_nonce_field' );
+		settings_fields( 'mitlib_alerts' );
+		do_settings_sections( 'mitlib-alerts-dashboard' );
+		submit_button( 'Update alerts settings' );
+		echo '</form>';
+		echo '</div>';
+
+	}
+
+	/**
+	 * This does the work of storing updated values when they are submitted via
+	 * the form.
+	 */
+	public static function update() {
+		// Check the nonce.
+		check_admin_referer( 'custom_nonce_action', 'custom_nonce_field' );
+
+		// Perform the updates. Looking up the action variable is duplicative - not sure how much that matters.
+		if ( 'update' == filter_input( INPUT_POST, 'action' ) ) {
+			// Set default values.
+			$source = '';
+
+			// Read the submitted values.
+			if ( filter_input( INPUT_POST, 'source' ) ) {
+				$source = sanitize_text_field(
+					wp_unslash( filter_input( INPUT_POST, 'source' ) )
+				);
+			}
+
+			// Store values.
+			update_option( 'source', $source );
+		}
+
+		echo '<div class="updated"><p>The Alerts API endpoint has been updated.</p></div>';
+
+	}
+}

--- a/lib/class-alerts-settings.php
+++ b/lib/class-alerts-settings.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Class that defines a settings form for network-wide alerts.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 2.1.0
+ */
+
+namespace Mitlib\Alerts;
+
+/**
+ * Defines the settings field used by the alerts system - a reference to the API
+ * from which alerts should be loaded.
+ */
+class Settings {
+
+	const PERMS = 'manage_options';
+
+	/**
+	 * Entry point for the settings - define the variable and the section which
+	 * contains it.
+	 */
+	public static function init() {
+		register_setting( 'mitlib_alerts', 'source' );
+
+		add_settings_section(
+			'mitlib_alerts_general',
+			'',
+			array( 'Mitlib\Alerts\Settings', 'general' ),
+			'mitlib-alerts-dashboard'
+		);
+
+		add_settings_field(
+			'source',
+			'Alerts API endpoint',
+			array( 'Mitlib\Alerts\Settings', 'source_callback' ),
+			'mitlib-alerts-dashboard',
+			'mitlib_alerts_general',
+			array(
+				'label_for' => 'source',
+				'class' => 'mitlib_alerts_row',
+			)
+		);
+	}
+
+	/**
+	 * This is an empty rendering callback, because the section which contains
+	 * the defined field doesn't need to display anything on the settings form.
+	 */
+	public static function general() {
+		echo '';
+	}
+
+	/**
+	 * This is the rendering callback for the settings field.
+	 */
+	public static function source_callback() {
+		$allowed_html = array(
+			'input' => array(
+				'type' => array(),
+				'name' => array(),
+				'value' => array(),
+				'id' => array(),
+				'size' => array(),
+			),
+			'p' => array(),
+		);
+
+		$template = '<input type="text" name="%s" value="%s" id="%s" size="60"><p>This should be the fully-qualified URL for the WordPress application which hosts Alert content. The original value was https://libraries.mit.edu/wp-json/wp/v2/posts/</p>';
+		$values = array(
+			'name' => 'source',
+			'value' => esc_attr( get_option( 'source' ) ),
+			'id' => 'source',
+		);
+		echo wp_kses( vsprintf( $template, $values ), $allowed_html );
+	}
+
+}

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries Tesseract
 Author: Lightning Trumpet, Pentagram, and Matt Bernhardt
 Author URI: https://github.com/matt-bernhardt
-Version: 2.0.1-@@branch-@@commit
+Version: 2.1.0-@@branch-@@commit
 
 A parent theme for the Pentagram-designed branding of the MIT Libraries
 


### PR DESCRIPTION
#### What does this PR do?

This defines a settings variable for implementing sites to define the source of alert messages. 

#### Helpful background context (if appropriate)

Our network of sites needs the capability to display alerts about library services, which are defined in one place and read out of that WP API.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ENGX-147

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
